### PR TITLE
Add VS Code Dev Container to build the firmware with just a couple of clicks

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -11,6 +11,7 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
      python3-pip \
      build-essential
 
+RUN ln -s /usr/bin/python3 /usr/bin/python
 
 RUN pip install -U https://github.com/platformio/platformio-core/archive/develop.zip
 RUN platformio update

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,18 @@
+# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.194.0/containers/ubuntu/.devcontainer/base.Dockerfile
+
+# [Choice] Ubuntu version: bionic, focal
+ARG VARIANT="focal"
+FROM mcr.microsoft.com/vscode/devcontainers/base:0-${VARIANT}
+
+
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+     && apt-get -y install --no-install-recommends \
+     python3 \
+     python3-pip \
+     build-essential
+
+
+RUN pip install -U https://github.com/platformio/platformio-core/archive/develop.zip
+RUN platformio update
+# To get the test platforms
+RUN pip install PyYaml

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,0 +1,1 @@
+Please see this video for instructions on how to use the Dev Container in VS Code https://youtu.be/bDl0vIotpAI. 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,35 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.194.0/containers/ubuntu
+{
+	"name": "Ubuntu",
+	"build": {
+		"dockerfile": "Dockerfile",
+		// Update 'VARIANT' to pick an Ubuntu version: focal, bionic
+		"args": { "VARIANT": "focal" }
+	},
+
+	// Set *default* container specific settings.json values on container create.
+	"settings": {},
+
+
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [
+		"platformio.platformio-ide",
+		"MarlinFirmware.auto-build"
+	],
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "uname -a",
+
+	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+	"remoteUser": "vscode",
+
+
+	"mounts": [
+		"source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind",
+		"source=${env:HOME}${env:USERPROFILE}/.ssh,target=/root/.ssh,type=bind,readonly",
+		"source=platformio-cache,target=/root/.platformio,type=volume"
+	]

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -30,6 +30,6 @@
 
 	"mounts": [
 		"source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind",
-		"source=${env:HOME}${env:USERPROFILE}/.ssh,target=/root/.ssh,type=bind,readonly",
+		"source=${env:HOME}${env:USERPROFILE}/.ssh,target=/home/vscode/.ssh,type=bind,readonly",
 		"source=platformio-cache,target=/root/.platformio,type=volume"
 	]


### PR DESCRIPTION
### Description



This PR adds a VS Code DevContainer with PlatformIO and Marlin build tooling and extensions pre-installed.

See this video for help on how to get started: https://www.youtube.com/watch?v=bDl0vIotpAI 




### Benefits

With Docker Desktop and VS Code installed, going from code pull to having a built firmware is a matter of minutes. No need to find and install dependencies. Just pull the code, open in the dev container and you're off to the races!
